### PR TITLE
pc_rpc.Server: Don't catch SystemExit exceptions

### DIFF
--- a/sipyco/pc_rpc.py
+++ b/sipyco/pc_rpc.py
@@ -550,7 +550,7 @@ class Server(_AsyncioServer):
             else:
                 raise ValueError("Unknown action: {}"
                                  .format(obj["action"]))
-        except asyncio.CancelledError:
+        except (asyncio.CancelledError, SystemExit):
             raise
         except:
             return {


### PR DESCRIPTION
sys.exit() inside an RPC method should still terminate the
server, rather than being marshalled across the RPC connection.

@sbourdeauducq: Okay? This just seems like an oversight to me,
but wanted to make sure it wasn't a conscious design decision.