### PR TITLE
pc_rpc.Server: Marshal exception on unencodable return value

### DIFF
--- a/sipyco/test/test_pc_rpc.py
+++ b/sipyco/test/test_pc_rpc.py
@@ -82,6 +82,8 @@ class RPCCase(unittest.TestCase):
             self.assertEqual(test_object, test_object_back)
             test_object_back = await remote.async_echo(test_object)
             self.assertEqual(test_object, test_object_back)
+            with self.assertRaises(TypeError):
+                await remote.return_unserializable()
             with self.assertRaises(AttributeError):
                 await remote.non_existing_method
             await remote.terminate()
@@ -144,6 +146,10 @@ class Echo:
     async def async_echo(self, x):
         await asyncio.sleep(0.01)
         return x
+
+    def return_unserializable(self):
+        # Arbitrary classes can't be PYON-serialized.
+        return Echo()
 
 
 def run_server():


### PR DESCRIPTION
This effectively just moves the pyon.encode() calls into the
try/except block in _process_action().

This way, the client acutally gets an exception if the return
value of a method call is not PYON-serializable instead of the
connection just being dropped, and the exception being swallowed
on the server side.

This is very useful to debug things in practice, as
 1) "… is not PYON-serializable" immediately points physicists who
    just use sipyco as a black box to what the error is, whereas a
    plain ConnectionResetError is rather inscrutable, and
 2) the exception message includes a string representation of the
    intended return value, further making it clear what is going on.