### PR TITLE
pyon: faster processing of ndarrays

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     url="https://m-labs.hk/artiq",
     description="Simple Python communications",
     license="LGPLv3+",
-    install_requires=["setuptools", "numpy"],
+    install_requires=["setuptools", "numpy", "pybase64"],
     packages=find_packages(),
     entry_points={
         "console_scripts": [

--- a/sipyco/pyon.py
+++ b/sipyco/pyon.py
@@ -18,13 +18,13 @@ function call syntax to express special data types.
 
 
 from operator import itemgetter
-import base64
 from fractions import Fraction
 from collections import OrderedDict
 import os
 import tempfile
 
 import numpy
+import pybase64 as base64
 
 
 _encode_map = {
@@ -152,16 +152,16 @@ class _Encoder:
         x = numpy.ascontiguousarray(x)
         r = "nparray("
         r += self.encode(x.shape) + ", "
-        r += self.encode(x.dtype.str) + ", "
-        r += self.encode(base64.b64encode(x.data))
-        r += ")"
+        r += self.encode(x.dtype.str) + ", b\""
+        r += base64.b64encode(x.data).decode()
+        r += "\")"
         return r
 
     def encode_npscalar(self, x):
         r = "npscalar("
-        r += self.encode(x.dtype.str) + ", "
-        r += self.encode(base64.b64encode(x.data))
-        r += ")"
+        r += self.encode(x.dtype.str) + ", b\""
+        r += base64.b64encode(x.data).decode()
+        r += "\")"
         return r
 
     def encode(self, x):


### PR DESCRIPTION
When dealing with large arrays, ``sync_struct`` and other RPC is pretty slow, which can be limiting (see e.g. m-labs/artiq#1128). 
This patch addresses part of the issue by providing faster serialization of large NumPy arrays.

Test code (timings obtained with IPython `%timeit` on the `pyon.encode` and `pyon.decode` lines):

```python
from sipyco import pyon
import numpy as np


raw = np.random.sample(int(1e7))

packed = pyon.encode(raw)
unpacked = pyon.decode(packed)

assert np.array_equal(unpacked, raw)
```

Profile without this patch:

![profile-orig](https://user-images.githubusercontent.com/44871469/99803656-2263de80-2b3a-11eb-868f-188a78224fec.png)

```
pyon.encode: 883 ms ± 3.09 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
pyon.decode: 853 ms ± 1.23 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Encoding is dominated by calls to `encode_bytes()` which calls `repr()` on a bytes from `base64encode()`. Hard-coding the bytes representation kills this problem:

![profile-bytes-encoding](https://user-images.githubusercontent.com/44871469/99803988-9aca9f80-2b3a-11eb-8c3d-ae221d268183.png)

```
pyon.encode: 199 ms ± 246 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
pyon.decode: 861 ms ± 1.23 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Going for a faster base64 encoder ([pybase64](https://github.com/mayeut/pybase64)) offers a more marginal but easy profit (also applicable to deserialization):

![profile-pybase64](https://user-images.githubusercontent.com/44871469/99804265-057bdb00-2b3b-11eb-8e6b-e92bc778bae3.png)

```
pyon.encode: 121 ms ± 1.65 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
pyon.decode: 682 ms ± 1.66 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
The dependency to [pybase64](https://github.com/mayeut/pybase64) is optional. Using `validate=True` as recommended in the readme gives a ca. 10 ms speed-up in this scenario. It's irrelevant since base64 decoding is not the limiting factor in `pyon.decode`.

I'm not sure what the remaining time spent in `encode_ndarray()` is made of. The profiler is surprisingly silent... String formatting (f-string) or `StringIO` buffering don't overperform string concatenation. The serializations of the shape and the dtype are negligible (one could use `repr(x.shape)` directly since we know that the shape is an tuple in integers but it doesn't really help further).

``pyon.decode`` is clearly dominated by the call to `eval()`. Any ideas of something easy and non-breaking one could do to improve on this?