### PR TITLE
pc_rpc: optimize socket read for synchronous clients

### DIFF
--- a/sipyco/pc_rpc.py
+++ b/sipyco/pc_rpc.py
@@ -55,6 +55,19 @@ def _validate_target_name(target_name, target_names):
     return target_name
 
 
+def _socket_readline(socket, bufsize=4096):
+    buf = socket.recv(bufsize).decode()
+    offset = 0
+    while buf.find("\n", offset) == -1:
+        more = socket.recv(bufsize)
+        if not more:
+            break
+        buf += more.decode()
+        offset += len(more)
+
+    return buf
+
+
 class Client:
     """This class proxies the methods available on the server so that they
     can be used as if they were local methods.
@@ -145,13 +158,8 @@ class Client:
         self.__socket.sendall(line.encode())
 
     def __recv(self):
-        buf = self.__socket.recv(4096).decode()
-        while "\n" not in buf:
-            more = self.__socket.recv(4096)
-            if not more:
-                break
-            buf += more.decode()
-        return pyon.decode(buf)
+        line = _socket_readline(self.__socket)
+        return pyon.decode(line)
 
     def __do_action(self, action):
         self.__send(action)
@@ -378,13 +386,8 @@ class BestEffortClient:
         self.__socket.sendall(line.encode())
 
     def __recv(self):
-        buf = self.__socket.recv(4096).decode()
-        while "\n" not in buf:
-            more = self.__socket.recv(4096)
-            if not more:
-                break
-            buf += more.decode()
-        return pyon.decode(buf)
+        line = _socket_readline(self.__socket)
+        return pyon.decode(line)
 
     def __do_rpc(self, name, args, kwargs):
         if self.__conretry_thread is not None:


### PR DESCRIPTION
This patch speeds up receiving large chunks of data in `pc_rpc.Client` and `pc_rpc.BestEffortClient`.

Profiling a call to `sipyco_rpctool` calling a method on a controller (in loopback) returning a 1e6-element NumPy array gives the following (sampling period is 10 ms):

![profile-old](https://user-images.githubusercontent.com/44871469/100116698-56aa0880-2e74-11eb-9cfb-4365a6c5cb16.png)

So the `__recv` method spends a lot of time calling `memchr` to find newline characters. This patch restricts the search to the new chunk of data, similarly to the implementation of `asyncio.StreamReader.readuntil`, speeding up the process considerably (same sampling period):

![profile-new](https://user-images.githubusercontent.com/44871469/100116861-8527e380-2e74-11eb-897c-143b92f3ec07.png)

Of course, this should play well with #16 and the call to `eval()` in `pyon.decode()` is again the bottleneck. Unit tests pass (although they don't test `pc_rpc.BestEffortClient`, correct?). The implementation is now shared between `pc_rpc.Client` and `pc_rpc.BestEffortClient`.