### PR TITLE
Add KEEPALIVE to socket connections

### DIFF
--- a/sipyco/broadcast.py
+++ b/sipyco/broadcast.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from sipyco.monkey_patches import *
-from sipyco import pyon
+from sipyco import keepalive, pyon
 from sipyco.asyncio_tools import AsyncioServer
 
 
@@ -18,7 +18,7 @@ class Receiver:
 
     async def connect(self, host, port):
         self.reader, self.writer = \
-            await asyncio.open_connection(host, port, limit=100*1024*1024)
+            await keepalive.open_connection(host, port, limit=100*1024*1024)
         try:
             self.writer.write(_init_string)
             self.writer.write((self.name + "\n").encode())

--- a/sipyco/keepalive.py
+++ b/sipyco/keepalive.py
@@ -1,0 +1,21 @@
+import sys
+import socket
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def set_keepalive(sock: socket, after_idle=10, interval=10, max_fails=3):
+    if sys.platform.startswith("linux"):
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, after_idle)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, interval)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, max_fails)
+    elif sys.platform.startswith("win") or sys.platform.startswith("cygwin"):
+        # setting max_fails is not supported, typically ends up being 5 or 10
+        # depending on Windows version
+        sock.ioctl(socket.SIO_KEEPALIVE_VALS,
+                   (1, after_idle * 1000, interval * 1000))
+    else:
+        logger.warning("TCP keepalive not supported on platform '%s', ignored",
+                       sys.platform)

--- a/sipyco/keepalive.py
+++ b/sipyco/keepalive.py
@@ -1,6 +1,7 @@
-import sys
-import socket
+import asyncio
 import logging
+import socket
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -19,3 +20,16 @@ def set_keepalive(sock: socket, after_idle=10, interval=10, max_fails=3):
     else:
         logger.warning("TCP keepalive not supported on platform '%s', ignored",
                        sys.platform)
+
+
+async def open_connection(host,
+                          port,
+                          after_idle=10,
+                          interval=10,
+                          max_fails=3,
+                          *args,
+                          **kwargs):
+    reader, writer = await asyncio.open_connection(host, port, *args, **kwargs)
+    sock = writer.get_extra_info('socket')
+    set_keepalive(sock, after_idle, interval, max_fails)
+    return reader, writer

--- a/sipyco/logging_tools.py
+++ b/sipyco/logging_tools.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import re
 
+from sipyco import keepalive
 from sipyco.monkey_patches import *
 from sipyco.asyncio_tools import TaskObject, AsyncioServer
 
@@ -194,8 +195,8 @@ class LogForwarder(logging.Handler, TaskObject):
         reader = writer = None
         while True:
             try:
-                reader, writer = await asyncio.open_connection(self.host,
-                                                               self.port)
+                reader, writer = await keepalive.open_connection(self.host,
+                                                                 self.port)
                 writer.write(_init_string)
                 while True:
                     message = await self._queue.get() + "\n"

--- a/sipyco/pc_rpc.py
+++ b/sipyco/pc_rpc.py
@@ -20,7 +20,7 @@ import time
 from operator import itemgetter
 
 from sipyco.monkey_patches import *
-from sipyco import pyon
+from sipyco import keepalive, pyon
 from sipyco.asyncio_tools import AsyncioServer as _AsyncioServer
 from sipyco.packed_exceptions import *
 
@@ -203,7 +203,7 @@ class AsyncioClient:
         this method is a coroutine. See :class:`sipyco.pc_rpc.Client` for a description of the
         parameters."""
         self.__reader, self.__writer = \
-            await asyncio.open_connection(host, port, limit=100*1024*1024)
+            await keepalive.open_connection(host, port, limit=100*1024*1024)
         try:
             self.__writer.write(_init_string)
             server_identification = await self.__recv()

--- a/sipyco/sync_struct.py
+++ b/sipyco/sync_struct.py
@@ -18,7 +18,7 @@ from functools import partial
 import logging
 
 from sipyco.monkey_patches import *
-from sipyco import pyon
+from sipyco import keepalive, pyon
 from sipyco.asyncio_tools import AsyncioServer
 
 
@@ -117,7 +117,7 @@ class Subscriber:
 
     async def connect(self, host, port, before_receive_cb=None):
         self.reader, self.writer = \
-            await asyncio.open_connection(host, port, limit=100*1024*1024)
+            await keepalive.open_connection(host, port, limit=100*1024*1024)
         try:
             if before_receive_cb is not None:
                 before_receive_cb()


### PR DESCRIPTION
### Symptom
When running `artiq_dashboard` we see SiPyCo connection errors to the master when left unattended.
We are running a Linux dashboard inside a Docker container running on WSL2 (Windows 10).

### Diagnosis
Inside a Docker container (Ubuntu running on WSL2) idle TCP socket connections drop out after 5 minutes.

This can be reproduced with a simple socket connection outside of SiPyCo.
On a server (Linux): `nc -l 0.0.0.0 1234`
In a container (Ubuntu/WSL2): `telnet <server ip> 1234`

### Solution
Sending KEEPALIVE packets before the connection dies prevents this.

Fix requires:
1) KEEPALIVE flag added to TCP socket connections
2) Reduce the keepalive time (default is 12 minutes)

For (2) we run Docker with following option: `docker run --sysctl net.ipv4.tcp_keepalive_time=200 ...`

### Implementation
I have created a `keepalive` module that sets up the flags (taking into account the operating system). This is then used to wrap calls to `asyncio.open_connection`.

The module can also be imported into Artiq to add KEEPALIVE to moninj/corelog connections.

### Testing
We have been running a local version of this change for the past 6 months with no issues.