### PR TITLE
pyon: supports zero-dimension numpy arrays

### DIFF
--- a/sipyco/pyon.py
+++ b/sipyco/pyon.py
@@ -149,7 +149,8 @@ class _Encoder:
         return "OrderedDict(" + self.encode(list(x.items())) + ")"
 
     def encode_nparray(self, x):
-        x = numpy.ascontiguousarray(x)
+        if numpy.ndim(x) > 0:
+            x = numpy.ascontiguousarray(x)
         r = "nparray("
         r += self.encode(x.shape) + ", "
         r += self.encode(x.dtype.str) + ", b\""


### PR DESCRIPTION
Signed-off-by: Mingyu Fan <mingyufan@ucsb.edu>

Currently `pyon.decode(pyon.encode(numpy.array(1)))` gives `numpy.array([1])` rather than `numpy.array(1)`. This PR should fix this problem by checking whether the array is zero-dimensional before calling `numpy.ascontiguousarray`.