### PR TITLE
Add TCP keepalive

### DIFF
--- a/sipyco/asyncio_tools.py
+++ b/sipyco/asyncio_tools.py
@@ -4,6 +4,8 @@ import collections
 import logging
 from copy import copy
 
+from sipyco import keepalive
+
 logger = logging.getLogger(__name__)
 
 
@@ -82,6 +84,7 @@ class AsyncioServer:
             logger.error("Client connection closed with error", exc_info=True)
 
     def _handle_connection(self, reader, writer):
+        keepalive.set_keepalive(writer.get_extra_info("socket"))
         task = asyncio.ensure_future(self._handle_connection_cr(reader, writer))
         self._client_tasks.add(task)
         task.add_done_callback(self._client_done)

--- a/sipyco/broadcast.py
+++ b/sipyco/broadcast.py
@@ -18,7 +18,7 @@ class Receiver:
 
     async def connect(self, host, port):
         self.reader, self.writer = \
-            await keepalive.open_connection(host, port, limit=100*1024*1024)
+            await keepalive.async_open_connection(host, port, limit=100 * 1024 * 1024)
         try:
             self.writer.write(_init_string)
             self.writer.write((self.name + "\n").encode())

--- a/sipyco/broadcast.py
+++ b/sipyco/broadcast.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from sipyco.monkey_patches import *
-from sipyco import pyon
+from sipyco import keepalive, pyon
 from sipyco.asyncio_tools import AsyncioServer
 
 
@@ -18,7 +18,7 @@ class Receiver:
 
     async def connect(self, host, port):
         self.reader, self.writer = \
-            await asyncio.open_connection(host, port, limit=100*1024*1024)
+            await keepalive.open_connection(host, port, limit=100*1024*1024)
         try:
             self.writer.write(_init_string)
             self.writer.write((self.name + "\n").encode())

--- a/sipyco/keepalive.py
+++ b/sipyco/keepalive.py
@@ -2,34 +2,104 @@ import asyncio
 import logging
 import socket
 import sys
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
 
-def set_keepalive(sock: socket, after_idle=10, interval=10, max_fails=3):
+def set_keepalive(
+        sock: socket,
+        after_idle: Optional[int] = None,
+        interval: Optional[int] = None,
+        max_fails: Optional[int] = None,
+):
+    """ Turn on keepalive and set options for socket
+
+    Args:
+        sock: The socket to target
+        after_idle: How long (in seconds) that the socket will be idle for
+            before sending the first keep alive.
+        interval: Time (in seconds) between keep alive packets.
+        max_fails: Number of probes to send before the connection fails.
+            Ignored on Windows, normally 5 or 10.
+
+    The defaults for the arguments are taken from the OS level defaults. These
+    can be controlled using sysctl on Linux, or the registry on Windows.
+    Normally it is sufficient to set these correctly only at one end of the
+    connection, the server is most convenient for this.
+
+    On Windows both or neither of after_idle and interval must be supplied and
+    max_fails is ignored. On all other OSs other than Linux all the arguments
+    are ignored.
+    """
+    # This is pretty portable actually, it works on at least Linux, Windows,
+    # some BSDs and Solaris.
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+
     if sys.platform.startswith("linux"):
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, after_idle)
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, interval)
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, max_fails)
+        if after_idle is not None:
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, after_idle)
+        if interval is not None:
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, interval)
+        if max_fails is not None:
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, max_fails)
     elif sys.platform.startswith("win") or sys.platform.startswith("cygwin"):
         # setting max_fails is not supported, typically ends up being 5 or 10
         # depending on Windows version
-        sock.ioctl(socket.SIO_KEEPALIVE_VALS,
-                   (1, after_idle * 1000, interval * 1000))
-    else:
-        logger.warning("TCP keepalive not supported on platform '%s', ignored",
-                       sys.platform)
+        if after_idle is not None and interval is not None:
+            sock.ioctl(socket.SIO_KEEPALIVE_VALS,
+                       (1, after_idle * 1000, interval * 1000))
+        elif after_idle is not None or interval is not None:
+            raise ValueError(
+                "Both or neither of after_idle and interval must be set on windows"
+            )
+
+    elif after_idle is not None or interval is not None or max_fails is not None:
+        logger.warning(
+            "Setting TCP keepalive options is not supported on %s",
+            sys.platform
+        )
 
 
-async def open_connection(host,
-                          port,
-                          after_idle=10,
-                          interval=10,
-                          max_fails=3,
-                          *args,
-                          **kwargs):
+async def async_open_connection(
+        host: str,
+        port: int,
+        *args: Any,
+        after_idle: Optional[int] = None,
+        interval: Optional[int] = None,
+        max_fails: Optional[int] = None,
+        **kwargs: Any,
+):
+    """ Open a socket and set keepalive options
+
+    Calls asyncio.open_connection to create the connection and set_keepalive to
+    setup the keepalive. Accepts all the arguments that asyncio.open_connection
+    does plus the after_idle, interval and max_fails arguments which are
+    forwarded to set_keepalive.
+    """
     reader, writer = await asyncio.open_connection(host, port, *args, **kwargs)
     sock = writer.get_extra_info('socket')
     set_keepalive(sock, after_idle, interval, max_fails)
     return reader, writer
+
+
+def create_connection(
+        host: str,
+        port: int,
+        *args: Any,
+        after_idle: Optional[int] = None,
+        interval: Optional[int] = None,
+        max_fails: Optional[int] = None,
+        **kwargs: Any,
+):
+    """Open a socket and set keepalive options
+
+    Calls socket.create_connection to create the connection and set_keepalive to
+    setup the keepalive. Accepts all the arguments that socket.create_connection
+    except that host and port are passed separately and used to form the address
+    tuple expected by socket.create_connection. Plus the after_idle, interval
+    and max_fails arguments which are forwarded to set_keepalive.
+    """
+    sock = socket.create_connection((host, port), *args, **kwargs)
+    set_keepalive(sock, after_idle, interval, max_fails)
+    return sock

--- a/sipyco/keepalive.py
+++ b/sipyco/keepalive.py
@@ -1,0 +1,21 @@
+import sys
+import socket
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def set_keepalive(sock: socket, after_idle=10, interval=10, max_fails=3):
+    if sys.platform.startswith("linux"):
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, after_idle)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, interval)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, max_fails)
+    elif sys.platform.startswith("win") or sys.platform.startswith("cygwin"):
+        # setting max_fails is not supported, typically ends up being 5 or 10
+        # depending on Windows version
+        sock.ioctl(socket.SIO_KEEPALIVE_VALS,
+                   (1, after_idle * 1000, interval * 1000))
+    else:
+        logger.warning("TCP keepalive not supported on platform '%s', ignored",
+                       sys.platform)

--- a/sipyco/keepalive.py
+++ b/sipyco/keepalive.py
@@ -1,6 +1,7 @@
-import sys
-import socket
+import asyncio
 import logging
+import socket
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -19,3 +20,16 @@ def set_keepalive(sock: socket, after_idle=10, interval=10, max_fails=3):
     else:
         logger.warning("TCP keepalive not supported on platform '%s', ignored",
                        sys.platform)
+
+
+async def open_connection(host,
+                          port,
+                          after_idle=10,
+                          interval=10,
+                          max_fails=3,
+                          *args,
+                          **kwargs):
+    reader, writer = await asyncio.open_connection(host, port, *args, **kwargs)
+    sock = writer.get_extra_info('socket')
+    set_keepalive(sock, after_idle, interval, max_fails)
+    return reader, writer

--- a/sipyco/logging_tools.py
+++ b/sipyco/logging_tools.py
@@ -195,8 +195,8 @@ class LogForwarder(logging.Handler, TaskObject):
         reader = writer = None
         while True:
             try:
-                reader, writer = await keepalive.open_connection(self.host,
-                                                                 self.port)
+                reader, writer = await keepalive.async_open_connection(self.host,
+                                                                       self.port)
                 writer.write(_init_string)
                 while True:
                     message = await self._queue.get() + "\n"

--- a/sipyco/logging_tools.py
+++ b/sipyco/logging_tools.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import re
 
+from sipyco import keepalive
 from sipyco.monkey_patches import *
 from sipyco.asyncio_tools import TaskObject, AsyncioServer
 
@@ -194,8 +195,8 @@ class LogForwarder(logging.Handler, TaskObject):
         reader = writer = None
         while True:
             try:
-                reader, writer = await asyncio.open_connection(self.host,
-                                                               self.port)
+                reader, writer = await keepalive.open_connection(self.host,
+                                                                 self.port)
                 writer.write(_init_string)
                 while True:
                     message = await self._queue.get() + "\n"

--- a/sipyco/pc_rpc.py
+++ b/sipyco/pc_rpc.py
@@ -211,7 +211,7 @@ class AsyncioClient:
         this method is a coroutine. See :class:`sipyco.pc_rpc.Client` for a description of the
         parameters."""
         self.__reader, self.__writer = \
-            await keepalive.open_connection(host, port, limit=100*1024*1024)
+            await keepalive.async_open_connection(host, port, limit=100 * 1024 * 1024)
         try:
             self.__writer.write(_init_string)
             server_identification = await self.__recv()

--- a/sipyco/pc_rpc.py
+++ b/sipyco/pc_rpc.py
@@ -20,7 +20,7 @@ import time
 from operator import itemgetter
 
 from sipyco.monkey_patches import *
-from sipyco import pyon
+from sipyco import keepalive, pyon
 from sipyco.asyncio_tools import AsyncioServer as _AsyncioServer
 from sipyco.packed_exceptions import *
 
@@ -211,7 +211,7 @@ class AsyncioClient:
         this method is a coroutine. See :class:`sipyco.pc_rpc.Client` for a description of the
         parameters."""
         self.__reader, self.__writer = \
-            await asyncio.open_connection(host, port, limit=100*1024*1024)
+            await keepalive.open_connection(host, port, limit=100*1024*1024)
         try:
             self.__writer.write(_init_string)
             server_identification = await self.__recv()

--- a/sipyco/sync_struct.py
+++ b/sipyco/sync_struct.py
@@ -117,7 +117,7 @@ class Subscriber:
 
     async def connect(self, host, port, before_receive_cb=None):
         self.reader, self.writer = \
-            await keepalive.open_connection(host, port, limit=100*1024*1024)
+            await keepalive.async_open_connection(host, port, limit=100 * 1024 * 1024)
         try:
             if before_receive_cb is not None:
                 before_receive_cb()

--- a/sipyco/sync_struct.py
+++ b/sipyco/sync_struct.py
@@ -18,7 +18,7 @@ from functools import partial
 import logging
 
 from sipyco.monkey_patches import *
-from sipyco import pyon
+from sipyco import keepalive, pyon
 from sipyco.asyncio_tools import AsyncioServer
 
 
@@ -117,7 +117,7 @@ class Subscriber:
 
     async def connect(self, host, port, before_receive_cb=None):
         self.reader, self.writer = \
-            await asyncio.open_connection(host, port, limit=100*1024*1024)
+            await keepalive.open_connection(host, port, limit=100*1024*1024)
         try:
             if before_receive_cb is not None:
                 before_receive_cb()


### PR DESCRIPTION
This continues on from https://github.com/m-labs/sipyco/pull/21 and addresses the comments there.

We think that this will be useful for a slightly different reason this time. We see occasional disconnects after 15 minutes of idle connection when connecting over VPN. Unfortunately we don't control the VPN configuration.

Makes the settings optional, so that the defaults from the OS will
be used by default. idle=10s, interval=10s and count=3 is quite
aggressive. For our current problem numbers in the minutes will
probably be more appropriate, and it seems inadvisable to bake
these in at this low level.
Adds doc-strings, comments and a sync `create_connection` function.
Also set the keepalive option on accepted connections in
AsyncioServer