### PR TITLE
Flake updates

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
     in rec {
       packages.x86_64-linux = {
         inherit sipyco sphinxcontrib-wavedrom latex-sipyco-manual;
+        default = sipyco;
         sipyco-manual-html = pkgs.stdenvNoCC.mkDerivation rec {
           name = "sipyco-manual-html-${version}";
           version = sipyco.version;
@@ -79,9 +80,7 @@
         };
       };
 
-      defaultPackage.x86_64-linux = packages.x86_64-linux.sipyco;
-
-      devShell.x86_64-linux = pkgs.mkShell {
+      devShells.x86_64-linux.default = pkgs.mkShell {
         name = "sipyco-dev-shell";
         buildInputs = [
           (pkgs.python3.withPackages(ps: with ps; [ pybase64 numpy ]))

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@
         src = self;
         propagatedBuildInputs = with pkgs.python3Packages; [ pybase64 numpy ];
       };
+      sipyco-aarch64 = (with nixpkgs.legacyPackages.aarch64-linux; python3Packages.buildPythonPackage {
+        inherit (sipyco) pname version src;
+        propagatedBuildInputs = with python3Packages; [ pybase64 numpy ];
+      });
       sphinxcontrib-wavedrom = pkgs.python3Packages.buildPythonPackage rec {
         pname = "sphinxcontrib-wavedrom";
         version = "3.0.2";
@@ -84,6 +88,11 @@
           pkgs.python3Packages.sphinx pkgs.python3Packages.sphinx_rtd_theme
           pkgs.python3Packages.sphinx-argparse sphinxcontrib-wavedrom latex-sipyco-manual
         ];
+      };
+
+      packages.aarch64-linux = {
+        sipyco = sipyco-aarch64;
+        default = sipyco-aarch64;
       };
 
       hydraJobs = {

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
       devShell.x86_64-linux = pkgs.mkShell {
         name = "sipyco-dev-shell";
         buildInputs = [
-          (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ pybase64 numpy ]))
+          (pkgs.python3.withPackages(ps: with ps; [ pybase64 numpy ]))
           pkgs.python3Packages.sphinx pkgs.python3Packages.sphinx_rtd_theme
           pkgs.python3Packages.sphinx-argparse sphinxcontrib-wavedrom latex-sipyco-manual
         ];


### PR DESCRIPTION
Adds aarch64 build for sipyco (closing #29), as well as minor fixes/updates. Tested the build on a RPi 4B with nix 2.7.0.