### PR TITLE
pc_rpc: Avoid BestEffortClient blocking forever on unresponsive servers

### DIFF
--- a/sipyco/pc_rpc.py
+++ b/sipyco/pc_rpc.py
@@ -336,13 +336,17 @@ class BestEffortClient:
         else:
             self.__socket = socket.create_connection(
                 (self.__host, self.__port), timeout)
-            self.__socket.settimeout(None)
         self.__socket.sendall(_init_string)
         server_identification = self.__recv()
         target_name = _validate_target_name(self.__target_name,
                                             server_identification["targets"])
         self.__socket.sendall((target_name + "\n").encode())
         self.__valid_methods = self.__recv()
+
+        # Only after the initial handshake is complete, disable the socket
+        # timeout (if any). Otherwise, the constructor can block forever if a
+        # server accepts the connection but does not respond.
+        self.__socket.settimeout(None)
 
     def __start_conretry(self):
         self.__conretry_thread = threading.Thread(target=self.__conretry)


### PR DESCRIPTION
A server that accepts connections but does not respond to communication
turns out to be a surprisingly common failure mode in practice given the
usual way of writing asyncio-based SiPyCo servers; for instance, because
of the server being deadlocked on internal synchronisation, or an user
having unwittingly blocked the terminal log output (activating copy
mode in cmd.exe, …).
