### PR TITLE
Allow parallel in simple server loop

### DIFF
--- a/sipyco/pc_rpc.py
+++ b/sipyco/pc_rpc.py
@@ -635,7 +635,7 @@ class Server(_AsyncioServer):
         await self._terminate_request.wait()
 
 
-def simple_server_loop(targets, host, port, description=None, *, loop=None):
+def simple_server_loop(targets, host, port, description=None, allow_parallel=False, *, loop=None):
     """Runs a server until an exception is raised (e.g. the user hits Ctrl-C)
     or termination is requested by a client.
 
@@ -650,7 +650,7 @@ def simple_server_loop(targets, host, port, description=None, *, loop=None):
         signal_handler = SignalHandler()
         signal_handler.setup()
         try:
-            server = Server(targets, description, True)
+            server = Server(targets, description, True, allow_parallel)
             used_loop.run_until_complete(server.start(host, port))
             try:
                 _, pending = used_loop.run_until_complete(asyncio.wait(


### PR DESCRIPTION
I found myself wanting this functionality in a fairly simple ndsp and had to essentially copy the `simple_server_loop` code verbatim to enable it; is there a reason the `allow_parallel` argument of `Server` should not be exposed?