### PR TITLE
pc_rpc: getattr error handling

### DIFF
--- a/sipyco/pc_rpc.py
+++ b/sipyco/pc_rpc.py
@@ -204,6 +204,7 @@ class AsyncioClient:
         self.__writer = None
         self.__target_names = None
         self.__description = None
+        self.__valid_methods = set()
 
     async def connect_rpc(self, host, port, target_name=AutoTarget):
         """Connects to the server. This cannot be done in __init__ because


### PR DESCRIPTION
Calling a method in `AsyncioClient` when the client has not yet connected yields a `RecursionError`:

```
  File "/home/srenblad/sipyco/test_script.py", line 6, in main                                                                                                                                                      
    await client.trigger()                                                                                                                                                                                          
          ^^^^^^^^^^^^^^                                                                                                                                                                                            
  File "/home/srenblad/sipyco/sipyco/pc_rpc.py", line 288, in __getattr__                                                                                                                                           
    if name not in self.__valid_methods:                                                                                                                                                                            
                   ^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                             
  File "/home/srenblad/sipyco/sipyco/pc_rpc.py", line 288, in __getattr__                                                                                                                                           
    if name not in self.__valid_methods:                                                                                                                                                                            
                   ^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                             
  File "/home/srenblad/sipyco/sipyco/pc_rpc.py", line 288, in __getattr__                                                                                                                                           
    if name not in self.__valid_methods:                                                                                                                                                                            
                   ^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                             
  [Previous line repeated 987 more times]                                                                                                                                                                           
RecursionError: maximum recursion depth exceeded
```

Proposal:
Throw an `AttributeError` instead:

```
  File "/home/srenblad/sipyco/test_script.py", line 6, in main
    await client.trigger()
          ^^^^^^^^^^^^^^
  File "/home/srenblad/sipyco/sipyco/pc_rpc.py", line 290, in __getattr__
    raise AttributeError
AttributeError
```