### PR TITLE
Add numpy dependency to setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-# Depends on numpy and optionally pybase64
+# optionally depends on pybase64
 
 setup(
     name="sipyco",
@@ -9,6 +9,9 @@ setup(
     url="https://m-labs.hk/artiq",
     description="Simple Python communications",
     license="LGPLv3+",
+    install_requires=[
+        "numpy",
+    ],
     packages=find_packages(),
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Add `numpy` as a dependency in the `setup.py` script so that full installation of `sipyco` succeeds with `pip` (not just `nix`).

Currently, `numpy` must be installed separately from `sipyco` for e.g. `sipyco_rpctool` to work when installing with `pip`.