### PR TITLE
sipyco_rpctool: fixing incompatible formatargspec call in python 3.11

### DIFF
--- a/sipyco/arguments.py
+++ b/sipyco/arguments.py
@@ -1,0 +1,38 @@
+# The inspect.formatargspec() function was dropped in Python 3.11 but we need
+# need it for when constructing signature changing decorators based on result of
+# inspect.getargspec() or inspect.getfullargspec(). The code here implements
+# inspect.formatargspec() base on Parameter and Signature from inspect module,
+# which were added in Python 3.6. Thanks to Cyril Jouve for the implementation.
+
+try:
+    from inspect import Parameter, Signature
+except ImportError:
+    from inspect import formatargspec
+else:
+    def formatargspec(args, varargs=None, varkw=None, defaults=None,
+                      kwonlyargs=(), kwonlydefaults={}, annotations={}):
+        if kwonlydefaults is None:
+            kwonlydefaults = {}
+        ndefaults = len(defaults) if defaults else 0
+        parameters = [
+            Parameter(
+                arg,
+                Parameter.POSITIONAL_OR_KEYWORD,
+                default=defaults[i] if i >= 0 else Parameter.empty,
+                annotation=annotations.get(arg, Parameter.empty),
+            ) for i, arg in enumerate(args, ndefaults - len(args))
+        ]
+        if varargs:
+            parameters.append(Parameter(varargs, Parameter.VAR_POSITIONAL))
+        parameters.extend(
+            Parameter(
+                kwonlyarg,
+                Parameter.KEYWORD_ONLY,
+                default=kwonlydefaults.get(kwonlyarg, Parameter.empty),
+                annotation=annotations.get(kwonlyarg, Parameter.empty),
+            ) for kwonlyarg in kwonlyargs
+        )
+        if varkw:
+            parameters.append(Parameter(varkw, Parameter.VAR_KEYWORD))
+        return_annotation = annotations.get('return', Signature.empty)
+        return str(Signature(parameters, return_annotation=return_annotation))

--- a/sipyco/sipyco_rpctool.py
+++ b/sipyco/sipyco_rpctool.py
@@ -7,6 +7,7 @@ import traceback
 import numpy as np  # Needed to use numpy in RPC call arguments on cmd line
 import pprint
 import inspect
+from .arguments import formatargspec
 
 from sipyco.pc_rpc import AutoTarget, Client
 

--- a/sipyco/sipyco_rpctool.py
+++ b/sipyco/sipyco_rpctool.py
@@ -48,7 +48,7 @@ def list_methods(remote):
         print(doc["docstring"])
         print()
     for name, (argspec, docstring) in sorted(doc["methods"].items()):
-        print(name + inspect.formatargspec(**argspec))
+        print(name + formatargspec(**argspec))
         if docstring is not None:
             print(textwrap.indent(docstring, "    "))
         print()


### PR DESCRIPTION
inspect.formatargspec is deprecated and unsupported from python 3.11
list-methods in sipyco_rcptool.py is broken due to a call to formatargspec (see [issue](https://github.com/m-labs/sipyco/issues/43))

Fix by defining a formatargspec function in arguments.py, based on Parameter and Signature from inspect module (fix taken from [wrapt module](https://github.com/GrahamDumpleton/wrapt/tree/develop/src/wrapt))