### PR TITLE
pyon: handle dict subclasses in `encode()`

### DIFF
--- a/sipyco/pyon.py
+++ b/sipyco/pyon.py
@@ -195,8 +195,11 @@ class _Encoder:
     def encode(self, x):
         ty = _encode_map.get(type(x), None)
         if ty is None:
-            raise TypeError("`{!r}` ({}) is not PYON serializable"
-                            .format(x, type(x)))
+            if isinstance(x, dict):
+                ty = "dict"
+            else:
+                raise TypeError("`{!r}` ({}) is not PYON serializable"
+                                .format(x, type(x)))
         getattr(self, "encode_" + ty)(x)
 
 


### PR DESCRIPTION
Allows PYON to serialize custom dict subclasses without requiring explicit dict() conversion.

Related issue:
https://github.com/m-labs/artiq/pull/2611#discussion_r1924902364