### PR TITLE
logging_tools: More informative invalid message format warning

### DIFF
--- a/sipyco/logging_tools.py
+++ b/sipyco/logging_tools.py
@@ -149,8 +149,9 @@ class Server(AsyncioServer):
                 else:
                     linesplit = line.split(":", maxsplit=1)
                     if len(linesplit) != 2:
+                        host = writer.get_extra_info("peername")
                         logger.warning("received improperly formatted message, "
-                                       "dropping connection")
+                                       "dropping connection to %s: '%s'", host, line)
                         return
                     source, remainder = linesplit
                     parser.line_input(remainder)


### PR DESCRIPTION
This extends the log message for improperly formatted log lines
to include the content of the line in question as well as the host
it was received from.

Previously, there was little chance of figure out what this was
triggered by (short of looking at a packet capture).
