### PR TITLE
pc_rpc: fix AsyncioClient.close_rpc

### DIFF
--- a/sipyco/pc_rpc.py
+++ b/sipyco/pc_rpc.py
@@ -231,7 +231,7 @@ class AsyncioClient:
             if target_name is not None:
                 await self.select_rpc_target(target_name)
         except:
-            self.close_rpc()
+            await self.close_rpc()
             raise
 
     async def select_rpc_target(self, target_name):
@@ -257,13 +257,14 @@ class AsyncioClient:
         identification information of the server."""
         return (self.__target_names, self.__description)
 
-    def close_rpc(self):
+    async def close_rpc(self):
         """Closes the connection to the RPC server.
 
         No further method calls should be done after this method is called.
         """
         if self.__writer is not None:
             self.__writer.close()
+            await self.__writer.wait_closed()
         self.__reader = None
         self.__writer = None
         self.__target_names = None

--- a/sipyco/test/test_pc_rpc.py
+++ b/sipyco/test/test_pc_rpc.py
@@ -88,7 +88,7 @@ class RPCCase(unittest.TestCase):
                 await remote.non_existing_method
             await remote.terminate()
         finally:
-            remote.close_rpc()
+            await remote.close_rpc()
 
     def _loop_asyncio_echo(self, target):
         loop = asyncio.new_event_loop()


### PR DESCRIPTION
### sipyco pull request

Running unit tests can result in an unclosed socket resource warning. Running with `tracemalloc` reveals it is from `AsyncioClient.close_rpc`. While `close` is called on the underlying writer, `wait_closed` is not awaited on (`close_rpc` is not async). As such, the socket is not guaranteed to be closed at the end of `close_rpc`. After adding `wait_closed`, the resource warnings are no longer observed.

This fix makes `close_rpc` async and **is a breaking API change**. Hence why I have marked it as a draft. Needs corresponding fixes in `artiq` main repo. 

