### PR TITLE
pc_rpc: fix socket leak when SSL handshake fails

### DIFF
--- a/sipyco/pc_rpc.py
+++ b/sipyco/pc_rpc.py
@@ -112,10 +112,10 @@ class Client:
     def __init__(self, host, port, target_name=AutoTarget,
                  timeout=None, ssl_config=None):
         self.__socket = socket.create_connection((host, port), timeout)
-        if ssl_config is not None:
-            ssl_context = ssl_config.create_client_context()
-            self.__socket = ssl_context.wrap_socket(self.__socket)
         try:
+            if ssl_config is not None:
+                ssl_context = ssl_config.create_client_context()
+                self.__socket = ssl_context.wrap_socket(self.__socket)
             self.__socket.sendall(_init_string)
 
             server_identification = self.__recv()


### PR DESCRIPTION
Fix `ResoureWarning` unclosed socket for non-async clients when SSL handshake fails. Shows up in `test_verification_fail` test in #50.

Related PR: #57.