### PR TITLE
change PYON format to be JSON

### DIFF
--- a/sipyco/pyon.py
+++ b/sipyco/pyon.py
@@ -228,12 +228,19 @@ def decode(s):
 
 
 def store_file(filename, x):
-    """Encodes a Python object and writes it to the specified file."""
+    """Encodes a Python object and writes it to the specified file.
+
+    The directory of the output must be writable.
+    """
     directory = os.path.abspath(os.path.dirname(filename))
     with tempfile.NamedTemporaryFile(
         "w", dir=directory, delete=False, encoding="utf-8"
     ) as f:
         json.dump(wrap(x), f, cls=_Encoder, indent=4)
+        # make sure that all data is on disk
+        # see http://stackoverflow.com/questions/7433057/is-rename-without-fsync-safe
+        f.flush()
+        os.fsync(f.fileno())
         tmpname = f.name
     os.replace(tmpname, filename)
 

--- a/sipyco/pyon.py
+++ b/sipyco/pyon.py
@@ -2,255 +2,169 @@
 This module provides serialization and deserialization functions for Python
 objects. Its main features are:
 
-* Human-readable format compatible with the Python syntax.
+* Human-readable format, fully compatible with JSON.
 * Each object is serialized on a single line, with only ASCII characters.
 * Supports all basic Python data structures: None, booleans, integers,
   floats, complex numbers, strings, tuples, lists, dictionaries.
-* Those data types are accurately reconstructed (unlike JSON where e.g. tuples
-  become lists, and dictionary keys are turned into strings).
-* Supports Numpy arrays. (Converted to be C-contiguous as required.)
-
-The main rationale for this new custom serializer (instead of using JSON) is
-that JSON does not support Numpy and more generally cannot be extended with
-other data types while keeping a concise syntax. Here we can use the Python
-function call syntax to express special data types.
+* Data types are accurately reconstructed and decode(encode()) round trips
+  maintain types. Tuples do not become lists, and dictionary keys are
+  not turned into strings.
+* Supports Numpy arrays and scalars. (Converted to be C-contiguous as required.)
 """
 
-
-from operator import itemgetter
 from fractions import Fraction
 from collections import OrderedDict
-import io
 import json
 import os
 import tempfile
 
 import numpy
+
 try:
     import pybase64 as base64
 except ImportError:
     import base64
 
 
+class Dict:
+    def __init__(self, data):
+        self.data = data
+
+
+class Tuple:
+    def __init__(self, data):
+        self.data = data
+
+
+def wrap(o):
+    if isinstance(o, dict):
+        o = {wrap(k): wrap(v) for k, v in o.items()}
+        if not all(isinstance(k, str) for k in o):
+            o = Dict(o)
+    elif isinstance(o, tuple):
+        o = Tuple(tuple(wrap(v) for v in o))
+    elif isinstance(o, list):
+        o = [wrap(v) for v in o]
+    elif isinstance(o, set):
+        o = {wrap(v) for v in o}
+    elif isinstance(o, slice):
+        o = slice(wrap(o.start), wrap(o.stop), wrap(o.step))
+    elif isinstance(o, OrderedDict):
+        o = OrderedDict((wrap(k), wrap(v)) for k, v in o.items())
+    return o
+
+
 _encode_map = {
-    type(None): "none",
-    bool: "bool",
-    int: "number",
-    float: "number",
-    complex: "number",
-    str: "str",
-    bytes: "bytes",
-    tuple: "tuple",
-    list: "list",
-    set: "set",
-    dict: "dict",
-    slice: "slice",
-    Fraction: "fraction",
-    OrderedDict: "ordereddict",
-    numpy.ndarray: "nparray"
-}
-
-_numpy_scalar = {
-    "int8", "int16", "int32", "int64",
-    "uint8", "uint16", "uint32", "uint64",
-    "float16", "float32", "float64",
-    "complex64", "complex128",
+    Tuple: ("tuple", lambda x: [list(x.data)]),
+    Dict: ("dict", lambda x: [list(x.data.items())]),
+    complex: ("complex", lambda x: [x.real, x.imag]),
+    bytes: ("bytes", lambda x: [base64.b64encode(x).decode()]),
+    set: ("set", lambda x: [list(x)]),
+    slice: ("slice", lambda x: [x.start, x.stop, x.step]),
+    Fraction: ("fraction", lambda x: [x.numerator, x.denominator]),
+    OrderedDict: ("ordered_dict", lambda x: [list(x.items())]),
 }
 
 
-for _t in _numpy_scalar:
-    _encode_map[getattr(numpy, _t)] = "npscalar"
+def _encode_nparray(x):
+    if numpy.ndim(x) > 0:
+        x = numpy.ascontiguousarray(x)
+    return [list(x.shape), x.dtype.str, base64.b64encode(x.data).decode()]
 
 
-class _Encoder:
-    __slots__ = ("pretty", "indent_level", "out")
+for _t in {
+    "ndarray",
+    "bool",
+    "bytes_",
+    "str_",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "intp",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "uintp",
+    "float16",
+    "float32",
+    "float64",
+    "float128",
+    "complex64",
+    "complex128",
+    "complex256",
+    "timedelta64",
+    "datetime64",
+    "void",
+}:
+    _encode_map[getattr(numpy, _t)] = ("ndarray", _encode_nparray)
 
-    def __init__(self, pretty):
-        self.pretty = pretty
-        self.indent_level = 0
-        self.out = []
 
-    def get_output(self):
-        return "".join(self.out)
-
-    def indent(self):
-        return "    "*self.indent_level
-
-    def encode_none(self, x):
-        self.out.append("null")
-
-    def encode_bool(self, x):
-        if x:
-            self.out.append("true")
-        else:
-            self.out.append("false")
-
-    def encode_number(self, x):
-        self.out.append(repr(x))
-
-    def encode_str(self, x):
-        # Do not use repr() for JSON compatibility.
-        self.out.append(json.dumps(x))
-
-    def encode_bytes(self, x):
-        self.out.append(repr(x))
-
-    def _encode_sequence(self, start, end, x):
-        self.out.append(start)
-        first = True
-        for item in x:
-            if not first:
-                self.out.append(", ")
-            first = False
-
-            self.encode(item)
-        self.out.append(end)
-
-    def encode_tuple(self, x):
-        if len(x) == 1:
-            self.out.append("(")
-            self.encode(x[0])
-            self.out.append(", )")
-        else:
-            self._encode_sequence("(", ")", x)
-
-    def encode_list(self, x):
-        self._encode_sequence("[", "]", x)
-
-    def encode_set(self, x):
-        self._encode_sequence("{", "}", x)
-
-    def encode_dict(self, x):
-        if self.pretty and all(k.__class__ == str for k in x.keys()):
-            items = lambda: sorted(x.items(), key=itemgetter(0))
-        else:
-            items = x.items
-
-        self.out.append("{")
-        if not self.pretty or len(x) < 2:
-            first = True
-            for k, v in items():
-                if not first:
-                    self.out.append(", ")
-                first = False
-
-                self.encode(k)
-                self.out.append(": ")
-                self.encode(v)
-        else:
-            self.indent_level += 1
-            self.out.append("\n")
-            indent = self.indent()
-            first = True
-            for k, v in items():
-                if not first:
-                    self.out.append(",\n")
-                first = False
-
-                self.out.append(indent)
-                self.encode(k)
-                self.out.append(": ")
-                self.encode(v)
-
-            self.out.append("\n")
-
-            self.indent_level -= 1
-            self.out.append(self.indent())
-
-        self.out.append("}")
-
-    def encode_slice(self, x):
-        self.out.append(repr(x))
-
-    def encode_fraction(self, x):
-        self.out.append("Fraction(")
-        self.encode(x.numerator)
-        self.out.append(", ")
-        self.encode(x.denominator)
-        self.out.append(")")
-
-    def encode_ordereddict(self, x):
-        self.out.append("OrderedDict(")
-        self.encode_list(x.items())
-        self.out.append(")")
-
-    def encode_nparray(self, x):
-        if numpy.ndim(x) > 0:
-            x = numpy.ascontiguousarray(x)
-        self.out.append("nparray(")
-        self.encode(x.shape)
-        self.out.append(", ")
-        self.encode(x.dtype.str)
-        self.out.append(", b\"")
-        self.out.append(base64.b64encode(x.data).decode())
-        self.out.append("\")")
-
-    def encode_npscalar(self, x):
-        self.out.append("npscalar(")
-        self.encode(x.dtype.str)
-        self.out.append(", b\"")
-        self.out.append(base64.b64encode(x.data).decode())
-        self.out.append("\")")
-
-    def encode(self, x):
-        ty = _encode_map.get(type(x), None)
-        if ty is None:
-            raise TypeError("`{!r}` ({}) is not PYON serializable"
-                            .format(x, type(x)))
-        getattr(self, "encode_" + ty)(x)
+class _Encoder(json.JSONEncoder):
+    def default(self, o):
+        try:
+            ty, enc = _encode_map[type(o)]
+        except KeyError:
+            raise TypeError("`{!r}` ({}) is not PYON serializable".format(o, type(o)))
+        return {"__jsonclass__": [ty, enc(o)]}
 
 
 def encode(x, pretty=False):
     """Serializes a Python object and returns the corresponding string in
-    Python syntax."""
-    encoder = _Encoder(pretty)
-    encoder.encode(x)
-    return encoder.get_output()
+    PYON syntax."""
+    if pretty:
+        indent = 4
+        separators = None
+    else:
+        indent = None
+        separators = (",", ":")
+    return json.dumps(wrap(x), cls=_Encoder, indent=indent, separators=separators)
 
 
-def _nparray(shape, dtype, data):
-    a = numpy.frombuffer(base64.b64decode(data), dtype=dtype)
-    a = a.copy()
-    return a.reshape(shape)
+def _decode_nparray(shape, dtype, data):
+    return numpy.frombuffer(base64.b64decode(data), dtype).copy().reshape(shape)
 
 
-def _npscalar(ty, data):
-    return numpy.frombuffer(base64.b64decode(data), dtype=ty)[0]
-
-
-_eval_dict = {
-    "__builtins__": {},
-
-    "null": None,
-    "false": False,
-    "true": True,
-    "inf": numpy.inf,
+_decode_map = {
+    "complex": complex,
+    "bytes": base64.b64decode,
+    "tuple": tuple,
     "slice": slice,
-    "nan": numpy.nan,
-
-    "Fraction": Fraction,
-    "OrderedDict": OrderedDict,
-    "nparray": _nparray,
-    "npscalar": _npscalar
+    "set": set,
+    "fraction": Fraction,
+    "dict": dict,
+    "ndarray": _decode_nparray,
+    "ordered_dict": OrderedDict,
 }
+
+
+assert set(name for name, _ in _encode_map.values()) == set(_decode_map.keys())
+
+
+def _object_hook(s):
+    try:
+        dec, args = s["__jsonclass__"]
+    except KeyError:
+        return s
+    return _decode_map[dec](*args)
 
 
 def decode(s):
     """
-    Parses a string in the Python syntax, reconstructs the corresponding
+    Parses a PYON string, reconstructs the corresponding
     object, and returns it.
-    **Shouldn't** be used with untrusted inputs, as it can cause vulnerability against injection attacks.
     """
-    return eval(s, _eval_dict, {})
+    return json.loads(s, object_hook=_object_hook)
 
 
 def store_file(filename, x):
     """Encodes a Python object and writes it to the specified file."""
-    contents = encode(x, True)
     directory = os.path.abspath(os.path.dirname(filename))
-    with tempfile.NamedTemporaryFile("w", dir=directory, delete=False, encoding="utf-8") as f:
-        f.write(contents)
-        f.write("\n")
+    with tempfile.NamedTemporaryFile(
+        "w", dir=directory, delete=False, encoding="utf-8"
+    ) as f:
+        json.dump(wrap(x), f, cls=_Encoder, indent=4)
         tmpname = f.name
     os.replace(tmpname, filename)
 
@@ -258,4 +172,4 @@ def store_file(filename, x):
 def load_file(filename):
     """Parses the specified file and returns the decoded Python object."""
     with open(filename, "r", encoding="utf-8") as f:
-        return decode(f.read())
+        return json.load(f, object_hook=_object_hook)

--- a/sipyco/pyon.py
+++ b/sipyco/pyon.py
@@ -3,13 +3,14 @@ This module provides serialization and deserialization functions for Python
 objects. Its main features are:
 
 * Human-readable format, fully compatible with JSON.
-* Each object is serialized on a single line, with only ASCII characters.
+* Can be serialized on a single line (for framing), with only ASCII characters.
 * Supports all basic Python data structures: None, booleans, integers,
-  floats, complex numbers, strings, tuples, lists, dictionaries.
-* Data types are accurately reconstructed and decode(encode()) round trips
-  maintain types. Tuples do not become lists, and dictionary keys are
-  not turned into strings.
+  floats, complex numbers, strings, tuples, lists, dictionaries, sets.
+* Type fidelity: Data types are accurately reconstructed and decode(encode())
+  round trips maintain types. Tuples do not become lists, and dictionary keys
+  are not turned into strings.
 * Supports Numpy arrays and scalars. (Converted to be C-contiguous as required.)
+* Extensible with custom type encoders/decoders.
 """
 
 from fractions import Fraction
@@ -37,43 +38,115 @@ class Tuple:
 
 
 def wrap(o):
+    """Wrap certain Python types to prevent coercion by `json`.
+
+    This recursively walks the three container types known to JSON (dict, list, tuple)
+    and wraps tuples in the custom `Tuple` type and dicts with non-str keys in the
+    custom `Dict` type.
+
+    If you implement PYON for a custom type with `register_type(), use this on your
+    inner values in the `encode()` handler.
+    """
     if isinstance(o, dict):
-        o = {wrap(k): wrap(v) for k, v in o.items()}
         if not all(isinstance(k, str) for k in o):
-            o = Dict(o)
+            return Dict([[wrap(k), wrap(v)] for k, v in o.items()])
+        else:
+            return {k: wrap(v) for k, v in o.items()}
     elif isinstance(o, tuple):
-        o = Tuple(tuple(wrap(v) for v in o))
+        return Tuple([wrap(v) for v in o])
     elif isinstance(o, list):
-        o = [wrap(v) for v in o]
-    elif isinstance(o, set):
-        o = {wrap(v) for v in o}
-    elif isinstance(o, slice):
-        o = slice(wrap(o.start), wrap(o.stop), wrap(o.step))
-    elif isinstance(o, OrderedDict):
-        o = OrderedDict((wrap(k), wrap(v)) for k, v in o.items())
-    return o
+        return [wrap(v) for v in o]
+    else:
+        return o
 
 
-_encode_map = {
-    Tuple: ("tuple", lambda x: [list(x.data)]),
-    Dict: ("dict", lambda x: [list(x.data.items())]),
-    complex: ("complex", lambda x: [x.real, x.imag]),
-    bytes: ("bytes", lambda x: [base64.b64encode(x).decode()]),
-    set: ("set", lambda x: [list(x)]),
-    slice: ("slice", lambda x: [x.start, x.stop, x.step]),
-    Fraction: ("fraction", lambda x: [x.numerator, x.denominator]),
-    OrderedDict: ("ordered_dict", lambda x: [list(x.items())]),
-}
+_encode_map = {}
+_decode_map = {}
+
+
+def register(types, *, name, encode, decode):
+    """Register custom Python types for encoding and decoding
+
+    Args:
+        types (iterable of types): Types to support by the encoder/decoder pair.
+        name (str): Unique name to hook the decoder.
+        encode (callable): Convert a value to arguments.
+            Called with of a type from `types`.
+            Returns a list of PYON-encodable arguments for `decode()`.
+            Use `wrap()` to prevent coercion of tuples and non-str dicts.
+        decode (callable): Convert arguments to a value.
+            Called with the PYON-decoded arguments from `encode()`.
+            Returns a value of a type from `types`.
+    """
+    assert all(t not in _encode_map for t in types)
+    assert name not in _decode_map
+    for t in types:
+        _encode_map[t] = name, encode
+    _decode_map[name] = decode
+
+
+def deregister(types, name):
+    """Deregister a set of types from the registry"""
+    assert all(_encode_map[t][0] == name for t in types)
+    del _decode_map[name]
+    for t in types:
+        del _encode_map[t]
+
+
+# Custom wrapper types to prevent coercion
+register([Tuple], name="tuple", encode=lambda x: [x.data], decode=tuple)
+register([Dict], name="dict", encode=lambda x: [x.data], decode=dict)
+
+# Additional PYON-supported types
+register([complex], name="complex", encode=lambda x: [x.real, x.imag], decode=complex)
+register(
+    [bytes],
+    name="bytes",
+    encode=lambda x: [base64.b64encode(x).decode()],
+    decode=base64.b64decode,
+)
+register([set], name="set", encode=lambda x: [[wrap(v) for v in x]], decode=set)
+register(
+    [slice],
+    name="slice",
+    encode=lambda x: [wrap(x.start), wrap(x.stop), wrap(x.step)],
+    decode=slice,
+)
+register(
+    [Fraction],
+    name="fraction",
+    encode=lambda x: [x.numerator, x.denominator],
+    decode=Fraction,
+)
+register(
+    [OrderedDict],
+    name="ordered_dict",
+    encode=lambda x: [[[wrap(k), wrap(v)] for k, v in x.items()]],
+    decode=OrderedDict,
+)
 
 
 def _encode_nparray(x):
-    if numpy.ndim(x) > 0:
-        x = numpy.ascontiguousarray(x)
-    return [list(x.shape), x.dtype.str, base64.b64encode(x.data).decode()]
+    return [
+        list(x.shape),
+        x.dtype.str,
+        base64.b64encode(numpy.ascontiguousarray(x).data).decode(),
+    ]
 
 
-for _t in {
-    "ndarray",
+def _decode_nparray(shape, dtype, data):
+    return numpy.frombuffer(base64.b64decode(data), dtype).copy().reshape(shape)
+
+
+register(
+    [numpy.ndarray],
+    name="nparray",
+    encode=_encode_nparray,
+    decode=_decode_nparray,
+)
+
+
+_np_types = {
     "bool",
     "bytes_",
     "str_",
@@ -81,12 +154,10 @@ for _t in {
     "int16",
     "int32",
     "int64",
-    "intp",
     "uint8",
     "uint16",
     "uint32",
     "uint64",
-    "uintp",
     "float16",
     "float32",
     "float64",
@@ -97,8 +168,26 @@ for _t in {
     "timedelta64",
     "datetime64",
     "void",
-}:
-    _encode_map[getattr(numpy, _t)] = ("ndarray", _encode_nparray)
+}
+
+
+def _encode_npscalar(x):
+    return [x.dtype.str, base64.b64encode(x.data).decode()]
+
+
+def _decode_npscalar(dtype, data):
+    return numpy.frombuffer(base64.b64decode(data), dtype)[0]
+
+
+register(
+    [getattr(numpy, t) for t in _np_types],
+    name="npscalar",
+    encode=_encode_npscalar,
+    decode=_decode_npscalar,
+)
+
+
+assert set(name for name, _ in _encode_map.values()) == set(_decode_map.keys())
 
 
 class _Encoder(json.JSONEncoder):
@@ -120,26 +209,6 @@ def encode(x, pretty=False):
         indent = None
         separators = (",", ":")
     return json.dumps(wrap(x), cls=_Encoder, indent=indent, separators=separators)
-
-
-def _decode_nparray(shape, dtype, data):
-    return numpy.frombuffer(base64.b64decode(data), dtype).copy().reshape(shape)
-
-
-_decode_map = {
-    "complex": complex,
-    "bytes": base64.b64decode,
-    "tuple": tuple,
-    "slice": slice,
-    "set": set,
-    "fraction": Fraction,
-    "dict": dict,
-    "ndarray": _decode_nparray,
-    "ordered_dict": OrderedDict,
-}
-
-
-assert set(name for name, _ in _encode_map.values()) == set(_decode_map.keys())
 
 
 def _object_hook(s):

--- a/sipyco/pyon.py
+++ b/sipyco/pyon.py
@@ -149,7 +149,7 @@ register(
 )
 
 
-_np_types = {
+_numpy_scalar = {
     "bool",
     "bytes_",
     "str_",
@@ -183,7 +183,7 @@ def _decode_npscalar(dtype, data):
 
 
 register(
-    [getattr(numpy, t) for t in _np_types],
+    [getattr(numpy, t) for t in _numpy_scalar],
     name="npscalar",
     encode=_encode_npscalar,
     decode=_decode_npscalar,
@@ -246,10 +246,10 @@ def store_file(filename, x, **kw):
     os.replace(tmpname, filename)
 
 
-def load_file(filename):
+def load_file(filename, **kw):
     """Decodes a Python object from a file"""
     with open(filename, "r", encoding="utf-8") as f:
-        return json.load(f, object_hook=_object_hook)
+        return json.load(f, object_hook=_object_hook, **kw)
 
 
 _eval_dict = {

--- a/sipyco/pyon.py
+++ b/sipyco/pyon.py
@@ -195,10 +195,10 @@ assert set(name for name, _ in _encode_map.values()) == set(_decode_map.keys())
 
 def _encode_default(o):
     try:
-        ty, enc = _encode_map[type(o)]
+        name, encode = _encode_map[type(o)]
     except KeyError:
         raise TypeError("`{!r}` ({}) is not PYON serializable".format(o, type(o)))
-    return {_jsonclass: [ty, enc(o)]}
+    return {_jsonclass: [name, encode(o)]}
 
 
 def encode(x, pretty=False, **kw):
@@ -216,10 +216,14 @@ def encode(x, pretty=False, **kw):
 
 def _object_hook(s):
     try:
-        dec, args = s[_jsonclass]
+        name, args = s[_jsonclass]
     except KeyError:
         return s
-    return _decode_map[dec](*args)
+    try:
+        decode = _decode_map[name]
+    except KeyError:
+        raise TypeError("`{}` is not PYON serializable".format(name))
+    return decode(*args)
 
 
 def decode(s, **kw):

--- a/sipyco/pyon.py
+++ b/sipyco/pyon.py
@@ -48,6 +48,7 @@ def wrap(o):
     inner values in the `encode()` handler.
     """
     if isinstance(o, dict):
+        assert "__jsonclass__" not in o
         if not all(isinstance(k, str) for k in o):
             return Dict([[wrap(k), wrap(v)] for k, v in o.items()])
         else:

--- a/sipyco/test/test_pc_rpc.py
+++ b/sipyco/test/test_pc_rpc.py
@@ -59,6 +59,8 @@ class RPCCase(unittest.TestCase):
             self.assertEqual(test_object, test_object_back)
             test_object_back = remote.async_echo(test_object)
             self.assertEqual(test_object, test_object_back)
+            with self.assertRaises(TypeError):
+                remote.return_unserializable()
             with self.assertRaises(AttributeError):
                 remote.non_existing_method
             if die_using_sys_exit:

--- a/sipyco/test/test_pyon.py
+++ b/sipyco/test/test_pyon.py
@@ -75,6 +75,20 @@ class PYON(unittest.TestCase):
         with self.assertRaises(TypeError):
             pyon.decode("{\"__jsonclass__\": [\"foo\", []]}")
 
+    def test_npscalars(self):
+        for t in pyon._numpy_scalar:
+            if t == "datetime64":
+                v = 0, "s"  # otherwise not-a-date
+            elif t == "bytes_":
+                v = (b"1",)  # can't frombuffer zero-size types
+            else:
+                v = (0,)
+            v = getattr(np, t)(*v)
+            with self.subTest(t):
+                e = pyon.encode(v)
+                d = pyon.decode(e)
+                self.assertEqual(d, v)
+
 
 _json_test_object = {
     "a": "b",
@@ -164,19 +178,3 @@ class CustomType(unittest.TestCase):
     def test_not_registered(self):
         with self.assertRaises(KeyError):
             pyon.deregister([None], "other")
-
-
-class NpScalarTypes(unittest.TestCase):
-    def test(self):
-        for t in pyon._numpy_scalar:
-            if t == "datetime64":
-                v = 0, "s"  # otherwise not-a-date
-            elif t == "bytes_":
-                v = (b"1",)  # numpy doesn't support zero-length bytes
-            else:
-                v = (0,)
-            v = getattr(np, t)(*v)
-            with self.subTest(t):
-                e = pyon.encode(v)
-                d = pyon.decode(e)
-                self.assertEqual(d, v)


### PR DESCRIPTION
This addresses several long-standing issues:

* No more `eval()` in `decode()` which is a step towards making the stack safer
* PYON v2 now _is_ JSON. This makes it easier for external non-Python code (e.g. our JS/TS or Rust code) to talk to sipyco/ARTIQ interfaces. The format is compatible with JSON-RPC v1 class hinting but that fact is not used, guaranteed, or tested.
* Support for custom types (superseding #22 and allowing #27 to be implemented by the user)
* Performance improvements: for the mid-size unittest data which is very heavy on low performing special cases, the relative time is 0.9 for `encode()` and 0.25 for `decode()` (lower than one is faster than before). For the large `twitter.json` dataset which is pure JSON the relative time is 0.3 for `encode()` and 0.07 for `decode()`. This has a significant impact since the ratio of `decode()` per `encode()` tends to be larger than one (in ARTIQ). `encode()` performance could probably be improved further with `orjson`.

The format is a bit more verbose, especially with pretty printing.

A PYON v1 -> v2 converter is included.

A data loss scenario in store_file() has been fixed that may have been involved in some corruption cases of the UI state files.

Several more unittests have been added.

Testing in ARTIQ is ongoing but apart from the migration and documentation I don't see a technical hurdle there. The API is backwards compatible, but since the wire format changes, it'll need some coordination.

Obviously this breaks using existing data (ARTIQ: dataset db, ui state files, devargs overrides, PYON arguments, PYON literals in experiments/CLI tools/GUI fields, HDF5 file contents, ...) or talking to sipyco interfaces running PYON v1.
Auto-migration would only be one-way, only works for files, doesn't work on the two-way sipyco interfaces, and roll-back is tricky since the user doesn't really track what's being migrated.
A transparent v1 fall-back is also only possible/helpful for decode().
One could do shadow or proxy interfaces for sipyco rpc/sync_struct etc. to ease the migration in distributed/heterogeneous deployments but that is quite a bit of work to implement and ultimately the coherent upgrade will require the same amount of user work.