### PR TITLE
pyon_v1: add back, pc_rpc: feature autonegotiation PYON backward/forward compat

### DIFF
--- a/sipyco/pc_rpc.py
+++ b/sipyco/pc_rpc.py
@@ -19,7 +19,7 @@ import threading
 import time
 from operator import itemgetter
 
-from sipyco import keepalive, pyon
+from sipyco import keepalive, pyon, pyon_v1
 from sipyco.tools import SignalHandler, AsyncioServer as _AsyncioServer
 from sipyco.packed_exceptions import *
 
@@ -86,6 +86,10 @@ class Client:
     automatically attempted. The user must call :meth:`~sipyco.pc_rpc.Client.close_rpc` to
     free resources properly after initialization completes successfully.
 
+    The ``pyon_v2`` (PYON v2 encoding) feature is supported and selected
+    when offered by the server. Future versions of the clients will require
+    the ``pyon_v2`` feature.
+
     :param host: Identifier of the server. The string can represent a
         hostname or a IPv4 or IPv6 address (see
         ``socket.create_connection`` in the Python standard library).
@@ -117,8 +121,15 @@ class Client:
                 ssl_context = ssl_config.create_client_context()
                 self.__socket = ssl_context.wrap_socket(self.__socket)
             self.__socket.sendall(_init_string)
-
+            self.__features = ""
+            self.__encode = pyon_v1.encode
+            self.__decode = pyon_v1.decode
             server_identification = self.__recv()
+            features = server_identification.get("features", [])
+            if "pyon_v2" in features:
+               self.__features += " pyon_v2"
+               self.__encode = pyon.encode
+               self.__decode = pyon.decode
             self.__target_names = server_identification["targets"]
             self.__description = server_identification["description"]
             self.__selected_target = None
@@ -133,7 +144,7 @@ class Client:
         """Selects a RPC target by name. This function should be called
         exactly once if the object was created with ``target_name=None``."""
         target_name = _validate_target_name(target_name, self.__target_names)
-        self.__socket.sendall((target_name + "\n").encode())
+        self.__socket.sendall((target_name + self.__features + "\n").encode())
         self.__selected_target = target_name
         self.__valid_methods = self.__recv()
 
@@ -159,12 +170,12 @@ class Client:
         self.__socket.close()
 
     def __send(self, obj):
-        line = pyon.encode(obj) + "\n"
+        line = self.__encode(obj) + "\n"
         self.__socket.sendall(line.encode())
 
     def __recv(self):
         line = _socket_readline(self.__socket)
-        return pyon.decode(line)
+        return self.__decode(line)
 
     def __do_action(self, action):
         self.__send(action)
@@ -223,7 +234,15 @@ class AsyncioClient:
             await keepalive.async_open_connection(host, port, ssl=ssl_context, limit=100 * 1024 * 1024)
         try:
             self.__writer.write(_init_string)
+            self.__features = ""
+            self.__encode = pyon_v1.encode
+            self.__decode = pyon_v1.decode
             server_identification = await self.__recv()
+            features = server_identification.get("features", [])
+            if "pyon_v2" in features:
+                self.__features += " pyon_v2"
+                self.__encode = pyon.encode
+                self.__decode = pyon.decode
             self.__target_names = server_identification["targets"]
             self.__description = server_identification["description"]
             self.__selected_target = None
@@ -239,7 +258,7 @@ class AsyncioClient:
         exactly once if the connection was created with ``target_name=None``.
         """
         target_name = _validate_target_name(target_name, self.__target_names)
-        self.__writer.write((target_name + "\n").encode())
+        self.__writer.write((target_name + self.__features + "\n").encode())
         self.__selected_target = target_name
         self.__valid_methods = await self.__recv()
 
@@ -271,14 +290,14 @@ class AsyncioClient:
         self.__description = None
 
     def __send(self, obj):
-        line = pyon.encode(obj) + "\n"
+        line = self.__encode(obj) + "\n"
         self.__writer.write(line.encode())
 
     async def __recv(self):
         line = await self.__reader.readline()
         if not line:
             raise EOFError("Connection closed unexpectedly")
-        return pyon.decode(line.decode())
+        return self.__decode(line.decode())
 
     async def __do_rpc(self, name, args, kwargs):
         await self.__lock.acquire()
@@ -356,10 +375,18 @@ class BestEffortClient:
             ssl_context = self.__ssl_config.create_client_context()
             self.__socket = ssl_context.wrap_socket(self.__socket)
         self.__socket.sendall(_init_string)
+        self.__features = ""
+        self.__encode = pyon_v1.encode
+        self.__decode = pyon_v1.decode
         server_identification = self.__recv()
+        features = server_identification.get("features", [])
+        if "pyon_v2" in features:
+            self.__features += " pyon_v2"
+            self.__encode = pyon.encode
+            self.__decode = pyon.decode
         target_name = _validate_target_name(self.__target_name,
                                             server_identification["targets"])
-        self.__socket.sendall((target_name + "\n").encode())
+        self.__socket.sendall((target_name + self.__features + "\n").encode())
         self.__valid_methods = self.__recv()
 
         # Only after the initial handshake is complete, disable the socket
@@ -404,12 +431,12 @@ class BestEffortClient:
             self.__conretry_terminate = True
 
     def __send(self, obj):
-        line = pyon.encode(obj) + "\n"
+        line = self.__encode(obj) + "\n"
         self.__socket.sendall(line.encode())
 
     def __recv(self):
         line = _socket_readline(self.__socket)
-        return pyon.decode(line)
+        return self.__decode(line)
 
     def __do_rpc(self, name, args, kwargs):
         if self.__conretry_thread is not None:
@@ -492,6 +519,10 @@ class Server(_AsyncioServer):
     otherwise a lock ensures that the calls from several clients are executed
     sequentially.
 
+    The ``pyon_v2`` (PYON v2 encoding) feature is supported and offered to
+    the client. Future versions of ``Server`` will require the ``pyon_v2``
+    feature.
+
     :param targets: A dictionary of objects providing the RPC methods to be
         exposed to the client. Keys are names identifying each object.
         Clients select one of these objects using its name upon connection.
@@ -505,10 +536,14 @@ class Server(_AsyncioServer):
         methods.
     """
 
-    def __init__(self, targets, description=None, builtin_terminate=False,
+    def __init__(self, targets, description="", builtin_terminate=False,
                  allow_parallel=False):
         _AsyncioServer.__init__(self)
+        if any(" " in name for name in targets):
+            raise ValueError("whitespace in target name")
         self.targets = targets
+        if not isinstance(description, str):
+            raise ValueError("description must be a `str`")
         self.description = description
         self.builtin_terminate = builtin_terminate
         if builtin_terminate:
@@ -585,9 +620,9 @@ class Server(_AsyncioServer):
             if self._noparallel is not None:
                 self._noparallel.release()
 
-    async def _process_and_pyonize(self, target, obj):
+    async def _process_and_pyonize(self, target, obj, encode):
         try:
-            return pyon.encode({
+            return encode({
                 "status": "ok",
                 "ret": await self._process_action(target, obj)
             })
@@ -599,7 +634,7 @@ class Server(_AsyncioServer):
             else:
                 raise
         except:
-            return pyon.encode({
+            return encode({
                 "status": "failed",
                 "exception": current_exc_packed()
             })
@@ -610,16 +645,31 @@ class Server(_AsyncioServer):
             if line != _init_string:
                 return
 
+            # For sipyco v2 and future servers this is encodable and decodable as
+            # pure JSON (and PYON v2) or PYON v1.
+            # For sipyco v1 servers it's PYON v1 if description == None.
             obj = {
                 "targets": sorted(self.targets.keys()),
-                "description": self.description
+                "description": self.description,
+                "features": ["pyon_v2"],
             }
             line = pyon.encode(obj) + "\n"
             writer.write(line.encode())
             line = await reader.readline()
             if not line:
                 return
-            target_name = line.decode()[:-1]
+            target_name, *features = line.decode()[:-1].split(" ")
+
+            encode = pyon_v1.encode
+            decode = pyon_v1.decode
+            for f in features:
+                if f == "pyon_v2":
+                    encode = pyon.encode
+                    decode = pyon.decode
+                else:
+                    logger.warning("Unsupported feature `%s`", f)
+                    return
+
             try:
                 target = self.targets[target_name]
             except KeyError:
@@ -632,14 +682,15 @@ class Server(_AsyncioServer):
             valid_methods = {m[0] for m in valid_methods}
             if self.builtin_terminate:
                 valid_methods.add("terminate")
-            writer.write((pyon.encode(valid_methods) + "\n").encode())
+            writer.write((encode(valid_methods) + "\n").encode())
 
             while True:
                 line = await reader.readline()
                 if not line:
                     break
                 reply = await self._process_and_pyonize(target,
-                                                        pyon.decode(line.decode()))
+                                                        decode(line.decode()),
+                                                        encode)
                 if reply is None:
                     return
                 writer.write((reply + "\n").encode())

--- a/sipyco/pyon.py
+++ b/sipyco/pyon.py
@@ -259,30 +259,6 @@ def load_file(filename, **kw):
         return json.load(f, object_hook=_object_hook, **kw)
 
 
-_v1_eval_dict = {
-    "__builtins__": {},
-    "null": None,
-    "false": False,
-    "true": True,
-    "inf": numpy.inf,
-    "slice": slice,
-    "nan": numpy.nan,
-    "Fraction": Fraction,
-    "OrderedDict": OrderedDict,
-    "nparray": _decode_nparray,
-    "npscalar": _decode_npscalar,
-}
-
-
-def decode_v1(s):
-    """
-    Deserializes a PYON v1 string and returns the reconstructed object
-
-    **Shouldn't** be used with untrusted inputs, as it can cause vulnerability against injection attacks.
-    """
-    return eval(s, _v1_eval_dict, {})
-
-
 if __name__ == "__main__":
     import argparse
 
@@ -293,6 +269,8 @@ Convert a PYON v1 file to JSON compliant PYON v2 in place.
 A backup of the input file is kept with the `_v1` extension.
 """.strip()
     )
+    from .pyon_v1 import decode as decode_v1
+
     parser.add_argument("file")
     args = parser.parse_args()
     obj = decode_v1(open(args.file, "r", encoding="utf-8").read())

--- a/sipyco/pyon.py
+++ b/sipyco/pyon.py
@@ -197,10 +197,10 @@ assert set(name for name, _ in _encode_map.values()) == set(_decode_map.keys())
 def _encode_default(o):
     try:
         name, encode = _encode_map[type(o)]
-    except KeyError:
+    except KeyError as e:
         raise TypeError(
-            f"`{o!r}`: `{o.__class__.__name__}` is not a registered PYON type"
-        )
+            f"`{o!r}`: Object of type `{o.__class__.__name__}` is not PYON encodable"
+        ) from e
     return {_jsonclass: [name, encode(o)]}
 
 
@@ -225,7 +225,7 @@ def _object_hook(s):
     try:
         decode = _decode_map[name]
     except KeyError:
-        raise TypeError(f"`{name}` is not a registered PYON type")
+        raise TypeError(f"Object of type `{name}` is not PYON decodable")
     return decode(*args)
 
 

--- a/sipyco/pyon_v1.py
+++ b/sipyco/pyon_v1.py
@@ -1,0 +1,261 @@
+"""
+This module provides serialization and deserialization functions for Python
+objects. Its main features are:
+
+* Human-readable format compatible with the Python syntax.
+* Each object is serialized on a single line, with only ASCII characters.
+* Supports all basic Python data structures: None, booleans, integers,
+  floats, complex numbers, strings, tuples, lists, dictionaries.
+* Those data types are accurately reconstructed (unlike JSON where e.g. tuples
+  become lists, and dictionary keys are turned into strings).
+* Supports Numpy arrays. (Converted to be C-contiguous as required.)
+
+The main rationale for this new custom serializer (instead of using JSON) is
+that JSON does not support Numpy and more generally cannot be extended with
+other data types while keeping a concise syntax. Here we can use the Python
+function call syntax to express special data types.
+"""
+
+
+from operator import itemgetter
+from fractions import Fraction
+from collections import OrderedDict
+import io
+import json
+import os
+import tempfile
+
+import numpy
+try:
+    import pybase64 as base64
+except ImportError:
+    import base64
+
+
+_encode_map = {
+    type(None): "none",
+    bool: "bool",
+    int: "number",
+    float: "number",
+    complex: "number",
+    str: "str",
+    bytes: "bytes",
+    tuple: "tuple",
+    list: "list",
+    set: "set",
+    dict: "dict",
+    slice: "slice",
+    Fraction: "fraction",
+    OrderedDict: "ordereddict",
+    numpy.ndarray: "nparray"
+}
+
+_numpy_scalar = {
+    "int8", "int16", "int32", "int64",
+    "uint8", "uint16", "uint32", "uint64",
+    "float16", "float32", "float64",
+    "complex64", "complex128",
+}
+
+
+for _t in _numpy_scalar:
+    _encode_map[getattr(numpy, _t)] = "npscalar"
+
+
+class _Encoder:
+    __slots__ = ("pretty", "indent_level", "out")
+
+    def __init__(self, pretty):
+        self.pretty = pretty
+        self.indent_level = 0
+        self.out = []
+
+    def get_output(self):
+        return "".join(self.out)
+
+    def indent(self):
+        return "    "*self.indent_level
+
+    def encode_none(self, x):
+        self.out.append("null")
+
+    def encode_bool(self, x):
+        if x:
+            self.out.append("true")
+        else:
+            self.out.append("false")
+
+    def encode_number(self, x):
+        self.out.append(repr(x))
+
+    def encode_str(self, x):
+        # Do not use repr() for JSON compatibility.
+        self.out.append(json.dumps(x))
+
+    def encode_bytes(self, x):
+        self.out.append(repr(x))
+
+    def _encode_sequence(self, start, end, x):
+        self.out.append(start)
+        first = True
+        for item in x:
+            if not first:
+                self.out.append(", ")
+            first = False
+
+            self.encode(item)
+        self.out.append(end)
+
+    def encode_tuple(self, x):
+        if len(x) == 1:
+            self.out.append("(")
+            self.encode(x[0])
+            self.out.append(", )")
+        else:
+            self._encode_sequence("(", ")", x)
+
+    def encode_list(self, x):
+        self._encode_sequence("[", "]", x)
+
+    def encode_set(self, x):
+        self._encode_sequence("{", "}", x)
+
+    def encode_dict(self, x):
+        if self.pretty and all(k.__class__ == str for k in x.keys()):
+            items = lambda: sorted(x.items(), key=itemgetter(0))
+        else:
+            items = x.items
+
+        self.out.append("{")
+        if not self.pretty or len(x) < 2:
+            first = True
+            for k, v in items():
+                if not first:
+                    self.out.append(", ")
+                first = False
+
+                self.encode(k)
+                self.out.append(": ")
+                self.encode(v)
+        else:
+            self.indent_level += 1
+            self.out.append("\n")
+            indent = self.indent()
+            first = True
+            for k, v in items():
+                if not first:
+                    self.out.append(",\n")
+                first = False
+
+                self.out.append(indent)
+                self.encode(k)
+                self.out.append(": ")
+                self.encode(v)
+
+            self.out.append("\n")
+
+            self.indent_level -= 1
+            self.out.append(self.indent())
+
+        self.out.append("}")
+
+    def encode_slice(self, x):
+        self.out.append(repr(x))
+
+    def encode_fraction(self, x):
+        self.out.append("Fraction(")
+        self.encode(x.numerator)
+        self.out.append(", ")
+        self.encode(x.denominator)
+        self.out.append(")")
+
+    def encode_ordereddict(self, x):
+        self.out.append("OrderedDict(")
+        self.encode_list(x.items())
+        self.out.append(")")
+
+    def encode_nparray(self, x):
+        if numpy.ndim(x) > 0:
+            x = numpy.ascontiguousarray(x)
+        self.out.append("nparray(")
+        self.encode(x.shape)
+        self.out.append(", ")
+        self.encode(x.dtype.str)
+        self.out.append(", b\"")
+        self.out.append(base64.b64encode(x.data).decode())
+        self.out.append("\")")
+
+    def encode_npscalar(self, x):
+        self.out.append("npscalar(")
+        self.encode(x.dtype.str)
+        self.out.append(", b\"")
+        self.out.append(base64.b64encode(x.data).decode())
+        self.out.append("\")")
+
+    def encode(self, x):
+        ty = _encode_map.get(type(x), None)
+        if ty is None:
+            raise TypeError("`{!r}` ({}) is not PYON serializable"
+                            .format(x, type(x)))
+        getattr(self, "encode_" + ty)(x)
+
+
+def encode(x, pretty=False):
+    """Serializes a Python object and returns the corresponding string in
+    Python syntax."""
+    encoder = _Encoder(pretty)
+    encoder.encode(x)
+    return encoder.get_output()
+
+
+def _nparray(shape, dtype, data):
+    a = numpy.frombuffer(base64.b64decode(data), dtype=dtype)
+    a = a.copy()
+    return a.reshape(shape)
+
+
+def _npscalar(ty, data):
+    return numpy.frombuffer(base64.b64decode(data), dtype=ty)[0]
+
+
+_eval_dict = {
+    "__builtins__": {},
+
+    "null": None,
+    "false": False,
+    "true": True,
+    "inf": numpy.inf,
+    "slice": slice,
+    "nan": numpy.nan,
+
+    "Fraction": Fraction,
+    "OrderedDict": OrderedDict,
+    "nparray": _nparray,
+    "npscalar": _npscalar
+}
+
+
+def decode(s):
+    """
+    Parses a string in the Python syntax, reconstructs the corresponding
+    object, and returns it.
+    **Shouldn't** be used with untrusted inputs, as it can cause vulnerability against injection attacks.
+    """
+    return eval(s, _eval_dict, {})
+
+
+def store_file(filename, x):
+    """Encodes a Python object and writes it to the specified file."""
+    contents = encode(x, True)
+    directory = os.path.abspath(os.path.dirname(filename))
+    with tempfile.NamedTemporaryFile("w", dir=directory, delete=False, encoding="utf-8") as f:
+        f.write(contents)
+        f.write("\n")
+        tmpname = f.name
+    os.replace(tmpname, filename)
+
+
+def load_file(filename):
+    """Parses the specified file and returns the decoded Python object."""
+    with open(filename, "r", encoding="utf-8") as f:
+        return decode(f.read())

--- a/sipyco/test/test_pyon.py
+++ b/sipyco/test/test_pyon.py
@@ -6,7 +6,7 @@ import tempfile
 
 import numpy as np
 
-from sipyco import pyon
+from sipyco import pyon, pyon_v1
 
 
 _pyon_test_object = {
@@ -126,7 +126,7 @@ class V1(unittest.TestCase):
         x = {
             (1, 2j): Fraction(4, 1),
         }
-        self.assertEqual(x, pyon.decode_v1(str(x)))
+        self.assertEqual(x, pyon_v1.decode(str(x)))
 
 
 class Custom:


### PR DESCRIPTION
This makes `pc_rpc` clients (all three) and servers backward and forward compatible.
It introduces feature negotiation between client and server and adds `pyon_v2` as one such feature. The server offers it in its greeting and the client selects it together with the target.
It also adds back `pyon_v1` as a new module to allow downstream users to opt out of PYON v2.