### PR TITLE
Fix README.rst and add installation hints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,32 @@
-SiPyCo (Simple Python Communications) is a library for writing networked Python programs. It was originally part of ARTIQ, and was split out to enable light-weight programs to be written without a dependency on ARTIQ.
+SiPyCo
+======
+
+SiPyCo (**Si**mple **Py**thon **Co**mmunications) is a library for writing networked Python programs.  
+It was originally part of ARTIQ, and was split out to enable light-weight programs to be written without a dependency on ARTIQ.
+
+Documentation
+-------------
 
 Documentation is available `here <https://m-labs.hk/artiq/sipyco-manual/>`_.
 
+Installation
+------------
+
+Using pip
+~~~~~~~~~
+
+.. code-block:: bash
+
+   pip install git+https://github.com/m-labs/sipyco
+
+
+Inside a Python project
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Add to ``pyproject.toml``
+
+.. code-block:: toml
+
+   dependencies = [
+     "sipyco @ git+https://github.com/m-labs/sipyco",
+   ]

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 SiPyCo
 ======
 
-SiPyCo (**Si**mple **Py**thon **Co**mmunications) is a library for writing networked Python programs.  
+SiPyCo (Simple Python Communications) is a library for writing networked Python programs.  
 It was originally part of ARTIQ, and was split out to enable light-weight programs to be written without a dependency on ARTIQ.
 
 Documentation

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
 SiPyCo (Simple Python Communications) is a library for writing networked Python programs. It was originally part of ARTIQ, and was split out to enable light-weight programs to be written without a dependency on ARTIQ.
 
-Documentation is available [here](https://m-labs.hk/artiq/sipyco-manual/).
+Documentation is available `here <https://m-labs.hk/artiq/sipyco-manual/>`_.
 


### PR DESCRIPTION
This PR

-  Fixes the markdown link in README.rst
- Add instructions on how to 
  - install SiPyCo using pip
  - use SiPyCo as dependency in Python projects

The latter is to help using the package outside of ARTIQ, which is the entire reason this repo exists.