### PR TITLE
dont wait_closed after client disconnect

### DIFF
--- a/sipyco/tools.py
+++ b/sipyco/tools.py
@@ -113,11 +113,15 @@ class AsyncioServer:
         task.add_done_callback(self._client_done)
 
     async def _handle_connection_and_close(self, reader, writer):
+        client_disconnect = False
         try:
             await self._handle_connection_cr(reader, writer)
+        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError):
+            client_disconnect = True
         finally:
             writer.close()
-            await writer.wait_closed()
+            if not client_disconnect:
+                await writer.wait_closed()
 
     async def _handle_connection_cr(self, reader, writer):
         raise NotImplementedError


### PR DESCRIPTION
Bug fix

Calling `wait_closed` on disconnected client causes `ConnectionError` which should be silenced.

Also moves client disconnect error handling to `_handle_connection_and_close`.

Caused by #62 

### Testing

Prior to fix, master may emit broken pipe errors when submitting experiments. After fix, this is not observed.